### PR TITLE
Provide module level event handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 var extend                = require('util')._extend
   , cookies               = require('./lib/cookies')
   , helpers               = require('./lib/helpers')
+  , events                = require('events')
 
 var isFunction            = helpers.isFunction
   , paramsHaveRequestBody = helpers.paramsHaveRequestBody
@@ -138,7 +139,10 @@ request.forever = function (agentOptions, optionsArg) {
 // Exports
 
 module.exports = request
+extend(request, events.prototype)
+events.call(request)
 request.Request = require('./request')
+request.Request.upstream = request
 request.initParams = initParams
 
 // Backwards compatibility for request.debug

--- a/request.js
+++ b/request.js
@@ -246,6 +246,7 @@ function Request (options) {
 
   var self = this
 
+  Request.upstream.emit('init')
   // start with HAR, then override with additional options
   if (options.har) {
     self._har = new Har(self)
@@ -258,6 +259,7 @@ function Request (options) {
 
   stream.Stream.call(self)
   util._extend(self, nonReserved)
+  util._extend(self._events, Request.upstream._events)
   options = filterOutReservedFunctions(reserved, options)
 
   self.readable = true
@@ -270,6 +272,7 @@ function Request (options) {
   self._multipart = new Multipart(self)
   self._redirect = new Redirect(self)
   self.init(options)
+  self.emit('initialized')
 }
 
 util.inherits(Request, stream.Stream)


### PR DESCRIPTION
Configure global, per-module event
handler to handle request initialization
errors:

```
var r = require('request').on('error', ...)
```

Per-module handlers are inherited by
Request object instances.
